### PR TITLE
Use correct format for links in documentation [ci skip]

### DIFF
--- a/lib/maru.ex
+++ b/lib/maru.ex
@@ -4,7 +4,7 @@ defmodule Maru do
   @moduledoc """
   This is documentation for maru.
 
-  Maru is a REST-like API micro-framework depends on (plug)[http://hexdocs.pm/plug] for (elixir)[http://elixir-lang.org] inspired by (grape)[https://github.com/ruby-grape/grape].
+  Maru is a REST-like API micro-framework depends on [plug](http://hexdocs.pm/plug) for [elixir](http://elixir-lang.org) inspired by [grape](https://github.com/ruby-grape/grape).
   """
 
   use Application


### PR DESCRIPTION
Now the links don't display correctly. http://hexdocs.pm/maru/0.8.4/Maru.html

See example in phoenix here: https://github.com/phoenixframework/phoenix/blob/1b281491fe054a2e2f047b9774d5e482c8a3cf8e/lib/phoenix.ex#L9
, and corresponding html page here http://hexdocs.pm/phoenix/Phoenix.html