### PR TITLE
Adds scope+namespace support for APIs mounted inside Phoenix

### DIFF
--- a/test/builder/routers_test.exs
+++ b/test/builder/routers_test.exs
@@ -2,6 +2,48 @@ defmodule Maru.Builder.RoutersTest do
   use ExUnit.Case, async: true
   import Maru.Builder.Routers
 
+  test "generate with namespace" do
+    defmodule NamespacedAPI do
+      use Maru.Router
+
+      get do
+        text conn, "get without version"
+      end
+
+      match do
+        text conn, "hehe"
+      end
+    end
+
+    namespace = "/api/foo/bar"
+
+    assert %{
+      nil => [
+        %Maru.Router.Endpoint{
+          block: {:text, _, [_, "hehe"]}, desc: nil, helpers: [],
+          method: {:_, [], nil}, param_context: [], path: [namespace], version: nil
+        },
+        %Maru.Router.Endpoint{
+          block: {:text, _, [_, "get without version"]}, desc: nil, helpers: [],
+          method: "GET", param_context: [], path: [namespace], version: nil
+        }
+      ],
+    } = generate(NamespacedAPI, [namespace])
+
+    assert %{
+      nil => [
+        %Maru.Router.Endpoint{
+          block: {:text, _, [_, "hehe"]}, desc: nil, helpers: [],
+          method: {:_, [], nil}, param_context: [], path: [namespace], version: nil
+        },
+        %Maru.Router.Endpoint{
+          block: {:text, _, [_, "get without version"]}, desc: nil, helpers: [],
+          method: "GET", param_context: [], path: [namespace], version: nil
+        }
+      ],
+    } = generate(NamespacedAPI, namespace)
+  end
+
   test "generate" do
     defmodule API do
       use Maru.Router


### PR DESCRIPTION
Found that using [Maru](http://github.com/falood/maru) APIs `forward`ed to by the [Phoenix](http://phoenixframework.org) router would get confused when nested inside `scope` and (or?) `namespace` clauses.  This PR fixes that.

---

Example problem:

Assume the `router.ex`:

```elixir
scope "/api" do
  pipe_through :api

  scope "/mob" do
    forward "/v1", Foo.Apis.Mobile.V1
  end
end
```

and the API, in `/web/apis/mobile/v1.ex`:

```elixir
defmodule Foo.Apis.Mobile.V1 do
  use Maru.Router

  namespace "/bars" do
    get "/", do: conn |> json %{status: "OK"}
  end
end
```

In this case, the router would not properly put together both the `scope` and `namespace` path components.  In the above example, the proper, fully-qualified path should be `/api/mob/v1/bars`, but `Maru.Builder.Routers.generate` was only producing `/bars`.