### PR TITLE
Add deps badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![Build Status](https://img.shields.io/travis/falood/maru.svg?style=flat-square)](https://travis-ci.org/falood/maru)
 [![Hex.pm Version](https://img.shields.io/hexpm/v/maru.svg?style=flat-square)](https://hex.pm/packages/maru)
+[![Deps Status](https://beta.hexfaktor.org/badge/all/github/falood/maru.svg?branch=master&style=flat-square)](https://beta.hexfaktor.org/github/falood/maru)
 [![Docs](https://inch-ci.org/github/falood/maru.svg?branch=master&style=flat-square)](https://inch-ci.org/github/falood/maru)
 [![Hex.pm Downloads](https://img.shields.io/hexpm/dt/maru.svg?style=flat-square)](https://hex.pm/packages/maru)
 ## Usage


### PR DESCRIPTION
Hi there,

I'm the maintainer of [Inch CI](https://inch-ci.org/) and this PR pitches my latest project for the Elixir community.

Here comes the pitch:

[![Deps Status](https://beta.hexfaktor.org/badge/all/github/falood/maru.svg?branch=master&style=flat-square)](https://beta.hexfaktor.org/github/falood/maru) [![Inline docs](http://inch-ci.org/github/falood/maru.svg?branch=master&style=flat-square)](http://inch-ci.org/github/falood/maru)

You already know the Inch badge on the right: It shows you an analysis for your Elixir project's docs. The new badge does the same thing for your dependencies.

Behind the badge works a CI service written in Elixir which can notify you whenever important updates for your Hex packages are released.

This is still in its infancy, and I want to basically invite you to join the beta to test-drive this. I really believe that we can create a great service for the community with this. That said, don't feel any obligation to accept the PR. You can't hurt my feelings by voicing your honest opinion about this idea!