### PR TITLE
Fix Dialyzer error

### DIFF
--- a/lib/maru/builder/parameter/helper.ex
+++ b/lib/maru/builder/parameter/helper.ex
@@ -70,7 +70,7 @@ defmodule Parameter.Helper do
           end
         end
       else
-        quote do
+        quote generated: true do
           fn {_, _, result} ->
             unquote(unpassed_func).(result)
           end


### PR DESCRIPTION
Adding a required parameter would make Dialyzer fail with "The created
fun has no local return".  This is true: Maru creates a fun that
handles the case when the parameter has not been passed in, which is
supposed to throw an error.  Let's make Dialyzer not warn about it by
declaring it as "generated code".

Fixes #100.